### PR TITLE
use a temporary folder before renaming to avoid problems

### DIFF
--- a/git_rewrite_merge_moveit.py
+++ b/git_rewrite_merge_moveit.py
@@ -102,7 +102,7 @@ def main(sysargv=None):
 
             call(['git', 'filter-branch', '-f',
                   '--tree-filter',
-                  'mkdir -p {0}; test "$(ls -A | grep -v {0})" && mv $(ls -A | grep -v {0}) {0} || true'
+                  'mkdir -p __tmp; test "$(ls -A | grep -v __tmp)" && mv $(ls -A | grep -v __tmp) __tmp && mv __tmp {0} || true'
                   .format(repo), 'HEAD'])
             print("==> Merging '{0}' branch from the '{1}' repository".format(branch, repo))
             call(['git', 'checkout', branch])


### PR DESCRIPTION
I think this will avoid the `moveit_ros` subfolder problem. I'm running it now. I'd recommend upgrading your git version if you're going to run it, rather than dropping the `--allow-unrelated-history` option. I just added the `git-core` ppa and got 2.9.2 on Trusty and it works fine.
